### PR TITLE
fix: fix unitialized accumulater pointers in case of KV cache splitting

### DIFF
--- a/csrc/build.rs
+++ b/csrc/build.rs
@@ -129,7 +129,7 @@ fn compile_cuda_files(build_dir: &Path) -> Result<()> {
         .arg("--expt-relaxed-constexpr")
         .arg("--expt-extended-lambda")
         .arg("--use_fast_math")
-        .arg("--verbose");
+        .arg("-w");
 
     println!("cargo:info={builder:?}");
 

--- a/csrc/kernels/flash_api.cu
+++ b/csrc/kernels/flash_api.cu
@@ -75,7 +75,10 @@ extern "C" void run_mha(
     int window_size_right,
     float softcap,
     bool unpadded_lse,
-    bool force_split_kernel=false
+    bool force_split_kernel,
+
+    void *softmax_lseaccum_ptr,
+    void *oaccum_ptr,
 ) {
     Flash_fwd_params params;
     // Reset the parameters
@@ -147,6 +150,9 @@ extern "C" void run_mha(
     params.softcap = softcap;
 
     params.unpadded_lse = unpadded_lse;
+
+    params.softmax_lseaccum_ptr = softmax_lseaccum_ptr;
+    params.oaccum_ptr = oaccum_ptr;
 
     cudaStream_t stream = 0; // Use the default stream.
     run_mha_fwd(params, stream, force_split_kernel);

--- a/csrc/src/ffi.rs
+++ b/csrc/src/ffi.rs
@@ -58,6 +58,9 @@ extern "C" {
         softcap: f32,
         unpadded_lse: bool,
         force_split_kernel: bool,
+
+        softmax_lseaccum_ptr: *const c_void,
+        oaccum_ptr: *const c_void
     );
 
     pub(crate) fn copy_blocks_f16(


### PR DESCRIPTION
## Motivation

The current implementation of Flash Attention lacks support for multi-split operations, which leads to memory illegal access for larger models or when processing longer sequences. This PR aims to address this limitation and improve overall performance.

## Description

This PR introduces support for multi-split operations in Flash Attention. Key changes include:

- Added `softmax_lseaccum_ptr` and `oaccum_ptr` parameters to the `run_mha` function to support accumulation across splits.
- Implemented logic to allocate and manage memory for these accumulators when `num_splits > 1`.
- Updated the FFI interface and Rust bindings to accommodate the new parameters.
- Refactored the `FlashAttention`, `FlashAttentionVarLen`, and `FlashAttentionKvCache` implementations to utilize the new multi-split functionality.
- Adjusted the CUDA compiler flags in `build.rs` to use `-w` instead of `--verbose` for more concise output.
- Made minor optimizations and code cleanup throughout the affected files.

## Breaking changes

This PR introduces the following breaking changes:

1. The `run_mha` function signature has been modified to include `softmax_lseaccum_ptr` and `oaccum_ptr` parameters. Any code directly calling this function will need to be updated.
2. The FFI interface for `run_mha` has been updated, which may require changes in any external bindings or integrations.
3. The behavior of Flash Attention operations may change slightly when `num_splits > 1`, potentially affecting output precision or performance characteristics in edge cases.