### PR TITLE
Fix test compilation failures

### DIFF
--- a/csrc/tests/flash_attn_tests.rs
+++ b/csrc/tests/flash_attn_tests.rs
@@ -208,7 +208,7 @@ fn flash_attn_kv_cache() -> Result<()> {
         let q = q.transpose(1, 2)?;
         let k = k.transpose(1, 2)?;
         let v = v.transpose(1, 2)?;
-        csrc::flash_attn_kv_cache_full(&q, &k, &v, None, 0.5, None, Some(&seqlens_k), None, false)?
+        csrc::flash_attn_kv_cache_full(&q, &k, &v, None, 0.5, None, Some(&seqlens_k), false)?
             .transpose(1, 2)?
     };
     let ys = ys.to_dtype(DType::F32)?;
@@ -260,7 +260,6 @@ fn test_flash_attn_kv_cache_with_block_table() -> Result<()> {
             0.5,
             block_table.as_ref(),
             Some(&seqlens_k),
-            None,
             false,
         )?
     };


### PR DESCRIPTION
Closes #65

Fixes the function args in uses of `flash_attn_kv_cache_full`, causing `cargo test` compilation to fail.