### PR TITLE
Adds logic for retrieving API key

### DIFF
--- a/server/src/api/chat_completions.rs
+++ b/server/src/api/chat_completions.rs
@@ -2,7 +2,7 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::{json, Value};
+use serde_json::Value;
 
 // TODO: fields that are named `r#type` should have values that represent
 // actual expected types that are deserializable from a string instead of
@@ -206,7 +206,7 @@ impl RequestBody {
                         r#type: "function".into(),
                         function: ToolCallFunction {
                             name: "myFunction".into(),
-                            arguments: json!({"key": "value"}),
+                            arguments: serde_json::json!({"key": "value"}),
                         },
                     }],
                 },

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,11 @@
 use std::env;
 
-use axum::{response::IntoResponse, routing::post, Json, Router};
+use axum::{
+    http::{header, HeaderMap},
+    response::IntoResponse,
+    routing::post,
+    Json, Router,
+};
 use serde_json::json;
 use tokio::net::TcpListener;
 
@@ -40,7 +45,18 @@ pub async fn run_server(listener: TcpListener) -> anyhow::Result<()> {
 
 /// Deserialize the `[RequestBody]` from JSON, and pass the information to the specified model,
 /// returning the generated content as a `[Response]` in JSON.
-pub async fn completion_handler(Json(request): Json<RequestBody>) -> impl IntoResponse {
+pub async fn completion_handler(
+    headers: HeaderMap,
+    Json(request): Json<RequestBody>,
+) -> impl IntoResponse {
+    if let Some(auth_header) = headers.get(header::AUTHORIZATION) {
+        if let Ok(auth_str) = auth_header.to_str() {
+            // Check if it starts with "Bearer" and extract the token
+            if let Some(token) = auth_str.strip_prefix("Bearer ") {
+                println!("Authorization token: {}", token);
+            }
+        }
+    }
     match &request.model() {
         // TODO: Use information from the deserialized request
         // and return the response from the model

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -21,6 +21,7 @@ pub mod api;
 pub const CHAT_COMPLETIONS_PATH: &str = "/chat/completions";
 pub const DEFAULT_SERVER_ADDRESS: &str = "0.0.0.0";
 pub const DEFAULT_SERVER_PORT: &str = "8080";
+pub const AUTH_BEARER_PREFIX: &str = "Bearer ";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -49,14 +50,15 @@ pub async fn completion_handler(
     headers: HeaderMap,
     Json(request): Json<RequestBody>,
 ) -> impl IntoResponse {
-    if let Some(auth_header) = headers.get(header::AUTHORIZATION) {
-        if let Ok(auth_str) = auth_header.to_str() {
-            // Check if it starts with "Bearer" and extract the token
-            if let Some(token) = auth_str.strip_prefix("Bearer ") {
-                println!("Authorization token: {}", token);
-            }
-        }
-    }
+    let _auth_key = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|auth_value| -> Option<&str> {
+            auth_value
+                .to_str()
+                .ok()
+                .and_then(|auth_header_str| auth_header_str.strip_prefix(AUTH_BEARER_PREFIX))
+        })
+        .unwrap_or_default();
     match &request.model() {
         // TODO: Use information from the deserialized request
         // and return the response from the model


### PR DESCRIPTION
Ref #77 

Retrieves the header for the `/chat/completions` route, extracting the bearer API key, or defaulting to an empty string slice.